### PR TITLE
Add animated gradient login screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,39 +1,122 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View, Button } from 'react-native';
-import React, { useState } from 'react';
+import React, { useRef } from 'react';
+import { StyleSheet, Text, TextInput, View, TouchableOpacity, Animated } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+const AnimatedTouchable = Animated.createAnimatedComponent(TouchableOpacity);
 
 export default function App() {
-  const [contador, setContador] = useState(0);
+  const loginScale = useRef(new Animated.Value(1)).current;
+  const signupScale = useRef(new Animated.Value(1)).current;
+
+  const bounce = (anim) => {
+    Animated.sequence([
+      Animated.timing(anim, { toValue: 0.95, duration: 100, useNativeDriver: true }),
+      Animated.spring(anim, { toValue: 1, friction: 3, useNativeDriver: true }),
+    ]).start();
+  };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.titulo}>Contador de Cliques</Text>
-      <Text style={styles.numero}>Você clicou {contador} vezes</Text>
+    <LinearGradient colors={['#4e0066', '#8a2be2']} style={styles.container}>
+      <View style={styles.lightOne} />
+      <View style={styles.lightTwo} />
 
-      <Button
-        title="Clique aqui"
-        onPress={() => setContador(contador + 1)}
-      />
-
-      <StatusBar style="auto" />
-    </View>
+      <View style={styles.form}>
+        <Text style={styles.title}>Bem-vindo</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Gmail"
+          placeholderTextColor="#ddd"
+          keyboardType="email-address"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Senha"
+          placeholderTextColor="#ddd"
+          secureTextEntry
+        />
+        <AnimatedTouchable
+          activeOpacity={0.8}
+          onPress={() => bounce(loginScale)}
+          style={{ transform: [{ scale: loginScale }], width: '100%' }}
+        >
+          <LinearGradient colors={['#8E2DE2', '#4A00E0']} style={styles.button}>
+            <Text style={styles.buttonText}>Login</Text>
+          </LinearGradient>
+        </AnimatedTouchable>
+        <AnimatedTouchable
+          activeOpacity={0.8}
+          onPress={() => bounce(signupScale)}
+          style={{ transform: [{ scale: signupScale }], width: '100%' }}
+        >
+          <LinearGradient colors={['#4A00E0', '#8E2DE2']} style={[styles.button, styles.buttonSecondary]}>
+            <Text style={styles.buttonText}>Cadastre-se</Text>
+          </LinearGradient>
+        </AnimatedTouchable>
+      </View>
+      <StatusBar style="light" />
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5c7d5ff',
-    alignItems: 'center',
     justifyContent: 'center',
+    alignItems: 'center',
   },
-  titulo: {
-    fontSize: 24,
+  lightOne: {
+    position: 'absolute',
+    width: 300,
+    height: 300,
+    borderRadius: 150,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    top: -80,
+    left: -80,
+  },
+  lightTwo: {
+    position: 'absolute',
+    width: 200,
+    height: 200,
+    borderRadius: 100,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    bottom: -50,
+    right: -50,
+  },
+  form: {
+    width: '80%',
+    padding: 25,
+    borderRadius: 20,
+    backgroundColor: 'rgba(0,0,0,0.25)',
+    zIndex: 1,
+  },
+  title: {
+    fontSize: 28,
     fontWeight: 'bold',
+    color: '#fff',
+    textAlign: 'center',
+    marginBottom: 30,
+  },
+  input: {
+    width: '100%',
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 15,
+    color: '#fff',
+  },
+  button: {
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: 'center',
     marginBottom: 15,
   },
-  numero: {
-    fontSize: 18,
-    marginBottom: 10,
+  buttonSecondary: {
+    marginTop: 0,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~5.0.4",
         "expo": "~53.0.20",
+        "expo-linear-gradient": "^14.1.5",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -4022,6 +4023,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "14.1.5",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-14.1.5.tgz",
+      "integrity": "sha512-BSN3MkSGLZoHMduEnAgfhoj3xqcDWaoICgIr4cIYEx1GcHfKMhzA/O4mpZJ/WC27BP1rnAqoKfbclk1eA70ndQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~5.0.4",
     "expo": "~53.0.20",
+    "expo-linear-gradient": "^14.1.5",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.5",
     "react-dom": "19.0.0",
-    "react-native-web": "^0.20.0",
-    "@expo/metro-runtime": "~5.0.4"
+    "react-native": "0.79.5",
+    "react-native-web": "^0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
## Summary
- implement purple gradient login screen with Gmail and password fields
- add animated login and sign-up buttons
- include expo-linear-gradient dependency for gradient effects

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cee0ead448320ab6ee2d701e0b48b